### PR TITLE
:arrow_up: Update yarn version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM node:carbon
 
-RUN npm install -g yarn --quiet
+# Remove the version of yarn that is coming with node:8 & Install latest yarn
+RUN rm -f /usr/local/bin/yarn && \
+  curl -o- -L https://yarnpkg.com/install.sh | bash && \
+  chmod +x ~/.yarn/bin/yarn && \
+  ln -s ~/.yarn/bin/yarn /usr/local/bin/yarn
 
 WORKDIR /app
 

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,11 @@ REDIS_URL=redis://redis:3679
 $ docker-compose up --build
 ```
 
+If you want dependencies back to host :
+```
+$ docker run -v "$(pwd)":/app:Z feely_feely yarn install
+```
+
 #### Troubleshooting
 ```
 $ docker-compose build --no-cache feely


### PR DESCRIPTION
Our Yarn installer was out of date and was causing issue and our
docker image is too old to have the most recent one.
Also update a bit the documentation.